### PR TITLE
Extract version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ or manually using this URL:
 
 First, you'll need to download `arduino-cli` from their official [GitHub page](https://github.com/arduino/arduino-cli/releases). Then all is left to do is to tell the plugin where you placed it via the settings.
 
-### Platfrom.io
+### Platform.io
 
 You first need to install PlatformIO-Core following their [official documentation](https://docs.platformio.org/en/latest/installation.html). Then as for Arduino, you need to tell the plugin where its installed.
 

--- a/octoprint_marlin_flasher/flasher/arduino_flasher.py
+++ b/octoprint_marlin_flasher/flasher/arduino_flasher.py
@@ -92,6 +92,7 @@ class ArduinoFlasher(BaseFlasher):
 									version = re.findall('"([^"]*)"', line)
 									if version:
 										self._firmware_version = version[0]
+										break
 							if self._firmware != None and version_txt != None:
 								self._firmware_version += " " + version_txt
 								return dict(
@@ -105,6 +106,7 @@ class ArduinoFlasher(BaseFlasher):
 									version = re.findall('"([^"]*)"', line)
 									if version:
 										version_txt = version[0]
+										break
 							if self._firmware != None and self._firmware_version != None:
 								self._firmware_version += " " + version_txt
 								return dict(

--- a/octoprint_marlin_flasher/flasher/arduino_flasher.py
+++ b/octoprint_marlin_flasher/flasher/arduino_flasher.py
@@ -64,6 +64,7 @@ class ArduinoFlasher(BaseFlasher):
 	def upload(self):
 		self._firmware = None
 		self._firmware_version = None
+		version_txt = None
 		uploaded_file_path = flask.request.values["firmware_file." + self._settings.get_upload_path_suffix()]
 		firmware_dir = os.path.join(self._plugin.get_plugin_data_folder(), "firmware_arduino")
 		if os.path.exists(firmware_dir):
@@ -79,19 +80,33 @@ class ArduinoFlasher(BaseFlasher):
 						if f == self._settings.get_arduino_sketch_ino():
 							self._firmware = root
 							self._firmware_upload_time = datetime.now()
-							if self._firmware_version != None:
+							if self._firmware_version != None and version_txt != None:
 								return dict(
 									path=root,
 									file=f
 								), None
 						if f == "Version.h":
-							versionfile = file(os.path.join(root, f))
+							versionfile = open(os.path.join(root, f), "r")
 							for line in versionfile:
 								if "SHORT_BUILD_VERSION" in line:
 									version = re.findall('"([^"]*)"', line)
 									if version:
 										self._firmware_version = version[0]
-							if self._firmware != None:
+							if self._firmware != None and version_txt != None:
+								self._firmware_version += " " + version_txt
+								return dict(
+									path=root,
+									file=self._settings.get_arduino_sketch_ino()
+								), None
+						if f == "Configuration.h":
+							versionfile = open(os.path.join(root, f), "r")
+							for line in versionfile:
+								if "STRING_CONFIG_H_AUTHOR" in line:
+									version = re.findall('"([^"]*)"', line)
+									if version:
+										version_txt = version[0]
+							if self._firmware != None and self._firmware_version != None:
+								self._firmware_version += " " + version_txt
 								return dict(
 									path=root,
 									file=self._settings.get_arduino_sketch_ino()

--- a/octoprint_marlin_flasher/flasher/base_flasher.py
+++ b/octoprint_marlin_flasher/flasher/base_flasher.py
@@ -11,6 +11,7 @@ class BaseFlasher:
 		self._plugin_manager = plugin_manager
 		self._identifier = identifier
 		self._firmware = None
+		self._firmware_version = None
 		self._firmware_upload_time = None
 		self._should_run_post_script = False
 

--- a/octoprint_marlin_flasher/flasher/platformio_flasher.py
+++ b/octoprint_marlin_flasher/flasher/platformio_flasher.py
@@ -73,6 +73,7 @@ class PlatformIOFlasher(BaseFlasher):
 								version = re.findall('"([^"]*)"', line)
 								if version:
 									self._firmware_version = version[0]
+									break
 						if self._firmware != None and version_txt != None:
 							self._firmware_version += " " + version_txt
 							return dict(
@@ -86,6 +87,7 @@ class PlatformIOFlasher(BaseFlasher):
 								version = re.findall('"([^"]*)"', line)
 								if version:
 									version_txt = version[0]
+									break
 						if self._firmware != None and self._firmware_version != None:
 							self._firmware_version += " " + version_txt
 							return dict(

--- a/octoprint_marlin_flasher/flasher/platformio_flasher.py
+++ b/octoprint_marlin_flasher/flasher/platformio_flasher.py
@@ -47,6 +47,7 @@ class PlatformIOFlasher(BaseFlasher):
 
 	def upload(self):
 		self._firmware = None
+		self._firmware_version = None
 		uploaded_file_path = flask.request.values["firmware_file." + self._settings.get_upload_path_suffix()]
 		with zipfile.ZipFile(uploaded_file_path, "r") as zip_file:
 			firmware_dir = os.path.join(self._plugin.get_plugin_data_folder(), "firmware_platformio")
@@ -59,10 +60,23 @@ class PlatformIOFlasher(BaseFlasher):
 					if f == "platformio.ini":
 						self._firmware = root
 						self._firmware_upload_time = datetime.now()
-						return dict(
-							path=root,
-							file=f
-						), None
+						if self._firmware_version != None:
+							return dict(
+								path=root,
+								file=f
+							), None
+					if f == "Version.h":
+						versionfile = file(os.path.join(root, f))
+						for line in versionfile:
+							if "SHORT_BUILD_VERSION" in line:
+								version = re.findall('"([^"]*)"', line)
+								if version:
+									self._firmware_version = version[0]
+						if self._firmware != None:
+							return dict(
+								path=root,
+								file="platformio.ini"
+							), None
 			return None, dict(
 				error=gettext("No Platform.io configuration file were found in the given file.")
 			)
@@ -70,6 +84,7 @@ class PlatformIOFlasher(BaseFlasher):
 	def firmware(self):
 		return dict(
 			firmware=self._firmware,
+			version=self._firmware_version,
 			upload_time=self._firmware_upload_time
 		), None
 
@@ -151,6 +166,7 @@ class PlatformIOFlasher(BaseFlasher):
 			self._wait_post_flash_delay()
 			self._printer.connect(port, baudrate, profile)
 			self._firmware = None
+			self._firmware_version = None
 			self._firmware_upload_time = None
 			self._should_run_post_script = True
 			self._plugin_manager.send_plugin_message(self._identifier, dict(

--- a/octoprint_marlin_flasher/static/js/marlin_flasher.js
+++ b/octoprint_marlin_flasher/static/js/marlin_flasher.js
@@ -25,6 +25,7 @@ $(function() {
         self.progressStep = ko.observable();
         self.flashButtonEnabled = ko.observable(false);
         self.boardOptionsLoading = ko.observable(false);
+        self.firmwareVersion = ko.observable();
         self.uploadTime = ko.observable();
         self.lastFlashOptions = null;
 
@@ -98,6 +99,7 @@ $(function() {
                     headers: OctoPrint.getRequestHeaders(),
                     url: "/plugin/marlin_flasher/firmware"
                 }).done(function(data) {
+                    self.firmwareVersion(data.version);
                     self.uploadTime(data.upload_time);
                 }).fail(function(jqXHR, status, error) {
                     self.showError(gettext("Upload time fetch failed"), jqXHR.responseJSON);

--- a/octoprint_marlin_flasher/templates/includes/group_items/arduino/flash.jinja2
+++ b/octoprint_marlin_flasher/templates/includes/group_items/arduino/flash.jinja2
@@ -3,6 +3,7 @@
         <a class="accordion-toggle" data-toggle="collapse" data-parent="#marlin_flasher_arduino_accordion" href="#flash">
             {{ _('Flash') }}
         </a>
+        <span data-bind="text: firmwareVersion() ? 'Version: ' + firmwareVersion() : ''"></span>
     </div>
     <div id="flash" class="accordion-body collapse">
         <div class="accordion-inner">

--- a/octoprint_marlin_flasher/templates/includes/group_items/platformio/flash.jinja2
+++ b/octoprint_marlin_flasher/templates/includes/group_items/platformio/flash.jinja2
@@ -3,6 +3,7 @@
         <a class="accordion-toggle" data-toggle="collapse" data-parent="#marlin_flasher_platformio_accordion" href="#platformio_flash">
             {{ _('Flash') }}
         </a>
+        <span data-bind="text: firmwareVersion() ? 'Version: ' + firmwareVersion() : ''"></span>
     </div>
     <div id="platformio_flash" class="accordion-body collapse">
         <div class="accordion-inner">


### PR DESCRIPTION
I often have different versions floating around when testing new Marlin releases.
To avoid confusion, I wanted to display the uploaded file's version.

This extracts and displays Marlin Version number (from Version.h)
Version number is displayed on the "Flash" heading

Only tested for the PlatformIO part (as I haven't used Arduino), but Arduino part should work just as well.