### PR TITLE
Octoprint 2.0.0 fixes

### DIFF
--- a/octoprint_marlin_flasher/__init__.py
+++ b/octoprint_marlin_flasher/__init__.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import
 import octoprint.plugin
 from octoprint.server.util.flask import restricted_access
 from octoprint.server import admin_permission

--- a/octoprint_marlin_flasher/__init__.py
+++ b/octoprint_marlin_flasher/__init__.py
@@ -289,7 +289,7 @@ class MarlinFlasherPlugin(octoprint.plugin.SettingsPlugin,
 
 
 __plugin_name__ = "Marlin Flasher"
-__plugin_pythoncompat__ = ">=2.7,<4"
+__plugin_pythoncompat__ = ">=3.7,<4"
 
 
 def __plugin_load__():

--- a/octoprint_marlin_flasher/__init__.py
+++ b/octoprint_marlin_flasher/__init__.py
@@ -1,6 +1,5 @@
 import octoprint.plugin
-from octoprint.server.util.flask import restricted_access
-from octoprint.server import admin_permission
+import octoprint.access.permissions as permissions
 from octoprint.events import Events
 import flask
 from .flasher import PlatformIOFlasher, ArduinoFlasher
@@ -126,68 +125,57 @@ class MarlinFlasherPlugin(octoprint.plugin.SettingsPlugin,
 	####################################################################
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/install", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def arduino_install(self):
 		return self.__handle_unvalidated_request(self.__arduino.start_install)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/upload_firmware", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def upload_arduino_firmware(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_upload, self.__arduino.upload, self.__arduino.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/download_firmware", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def download_arduino_firmware(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_download, self.__arduino.download, self.__arduino.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/cores/search", methods=["GET"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def search_arduino_cores(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_core_search, self.__arduino.core_search, self.__arduino.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/cores/install", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def install_arduino_core(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_core_install, self.__arduino.core_install, self.__arduino.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/cores/uninstall", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def uninstall_arduino_core(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_core_uninstall, self.__arduino.core_uninstall, self.__arduino.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/libs/search", methods=["GET"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def search_arduino_libs(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_lib_search, self.__arduino.lib_search, self.__arduino.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/libs/install", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def install_arduino_lib(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_lib_install, self.__arduino.lib_install, self.__arduino.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/libs/uninstall", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def uninstall_arduino_lib(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_lib_uninstall, self.__arduino.lib_uninstall, self.__arduino.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/board/details", methods=["GET"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def board_detail(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_board_details, self.__arduino.board_details, self.__arduino.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/arduino/flash", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def arduino_flash(self):
 		return self.__handle_validated_request(self.__arduino_validator.validate_flash, self.__arduino.flash, self.__arduino.check_setup_errors)
 
@@ -196,50 +184,42 @@ class MarlinFlasherPlugin(octoprint.plugin.SettingsPlugin,
 	####################################################################
 
 	@octoprint.plugin.BlueprintPlugin.route("/platformio/install", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def platformio_install(self):
 		return self.__handle_unvalidated_request(self.__platformio.start_install)
 
 	@octoprint.plugin.BlueprintPlugin.route("/platformio/upload_firmware", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def upload_platformio_firmware(self):
 		return self.__handle_validated_request(self.__platformio_validator.validate_upload, self.__platformio.upload, self.__platformio.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/platformio/download_firmware", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def download_platoformio_firmware(self):
 		return self.__handle_validated_request(self.__platformio_validator.validate_download, self.__platformio.download, self.__platformio.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/platformio/flash", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def platformio_flash(self):
 		return self.__handle_validated_request(self.__platformio_validator.validate_flash, self.__platformio.flash, self.__platformio.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/platformio/account/login", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def platformio_login(self):
 		return self.__handle_validated_request(self.__platformio_validator.validate_login, self.__platformio.login, self.__platformio.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/platformio/account/logout", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def platformio_logout(self):
 		return self.__handle_validated_request(self.__platformio_validator.validate_logout, self.__platformio.logout, self.__platformio.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/platformio/agent/start", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def platformio_start_remote_agent(self):
 		return self.__handle_validated_request(self.__platformio_validator.validate_start_remote_agent, self.__platformio.start_remote_agent, self.__platformio.check_setup_errors)
 
 	@octoprint.plugin.BlueprintPlugin.route("/platformio/agent/stop", methods=["POST"])
-	@restricted_access
-	@admin_permission.require(403)
+	@permissions.Permissions.ADMIN.require(403)
 	def platformio_stop_remote_agent(self):
 		return self.__handle_validated_request(self.__platformio_validator.validate_stop_remote_agent, self.__platformio.stop_remote_agent, self.__platformio.check_setup_errors)
 

--- a/octoprint_marlin_flasher/flasher/__init__.py
+++ b/octoprint_marlin_flasher/flasher/__init__.py
@@ -1,2 +1,0 @@
-from .platformio_flasher import PlatformIOFlasher
-from .arduino_flasher import ArduinoFlasher

--- a/octoprint_marlin_flasher/flasher/arduino_flasher.py
+++ b/octoprint_marlin_flasher/flasher/arduino_flasher.py
@@ -340,11 +340,11 @@ class ArduinoFlasher(BaseFlasher):
 		options = []
 		for param in flask.request.values:
 			if param != "fqbn":
-				options.append("%s=%s" % (param, flask.request.values[param]))
+				options.append("{}={}".format(param, flask.request.values[param]))
 		options = ",".join(options)
 		fqbn = flask.request.values["fqbn"]
 		if options:
-			fqbn = "%s:%s" % (fqbn, options)
+			fqbn = "{}:{}".format(fqbn, options)
 		thread = Thread(target=self.__background_flash, args=(fqbn,))
 		thread.start()
 		self._logger.debug("Saving options")

--- a/octoprint_marlin_flasher/flasher/base_flasher.py
+++ b/octoprint_marlin_flasher/flasher/base_flasher.py
@@ -105,7 +105,7 @@ class BaseFlasher:
 			for f in files:
 				if f == "Version.h":
 					self._logger.debug("Found Version.h, opening it...")
-					with open(os.path.join(root, f), "r") as version_file:
+					with open(os.path.join(root, f)) as version_file:
 						for line in version_file:
 							version = re.findall(r'#define +SHORT_BUILD_VERSION +"([^"]*)"', line)
 							if version:
@@ -114,7 +114,7 @@ class BaseFlasher:
 								break
 				elif f == "Configuration.h":
 					self._logger.debug("Found Configuration.h, opening it...")
-					with open(os.path.join(root, f), "r") as configfile:
+					with open(os.path.join(root, f)) as configfile:
 						for line in configfile:
 							author = re.findall(r'#define +STRING_CONFIG_H_AUTHOR +"([^"]*)"', line)
 							if author:

--- a/octoprint_marlin_flasher/flasher/platformio_flasher.py
+++ b/octoprint_marlin_flasher/flasher/platformio_flasher.py
@@ -265,7 +265,7 @@ class PlatformIOFlasher(BaseFlasher):
 			return []
 		try:
 			self._logger.debug("Trying to open Configuration.h")
-			with open(os.path.join(self._firmware, "Marlin", "Configuration.h"), "r") as configuration_h:
+			with open(os.path.join(self._firmware, "Marlin", "Configuration.h")) as configuration_h:
 				configuration_h_content = configuration_h.read()
 				match = re.search(r"^\s*?#define\s+?MOTHERBOARD\s+?(\S*?)\s*?$", configuration_h_content, re.MULTILINE)
 				if not match:
@@ -274,7 +274,7 @@ class PlatformIOFlasher(BaseFlasher):
 				self._logger.debug("Found motherboard %s" % match.group(1))
 				motherboard = match.group(1)[6:]
 				self._logger.debug("Trying to open pins.h")
-				with open(os.path.join(self._firmware, "Marlin", "src", "pins", "pins.h"), "r") as pins_h:
+				with open(os.path.join(self._firmware, "Marlin", "src", "pins", "pins.h")) as pins_h:
 					pins_h_content = pins_h.read()
 					match = re.search(r"^\s*?#(el)?if\s+?MB\([^)]*?%s[^)]*?\)\s*?\n.*?(env:.*?)\s*?$" % re.escape(motherboard), pins_h_content, re.MULTILINE)
 					if not match:
@@ -282,7 +282,7 @@ class PlatformIOFlasher(BaseFlasher):
 					self._logger.debug("Found environments %s" % match.group(2))
 					envs = [env[4:] for env in match.group(2).strip().split(" ") if env.startswith("env:")]
 					return envs
-		except (OSError, IOError) as _:
+		except OSError as _:
 			# Files are not where they should, maybe it's not Marlin... No env found, the user will select the default one
 			self._logger.debug("Could not open file")
 			return []

--- a/octoprint_marlin_flasher/settings/__init__.py
+++ b/octoprint_marlin_flasher/settings/__init__.py
@@ -1,1 +1,0 @@
-from .settings_wrapper import SettingsWrapper

--- a/octoprint_marlin_flasher/validation/__init__.py
+++ b/octoprint_marlin_flasher/validation/__init__.py
@@ -1,2 +1,0 @@
-from .arduino_validator import ArduinoValidator
-from .platformio_validator import PlatformIOValidator

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-
 import setuptools
 
 # we define the license string like this to be backwards compatible to setuptools<77


### PR DESCRIPTION
Hi, I'm an active contributor to OctoPrint core. I helped ship [OctoPrint 2.0.0rc1](https://github.com/OctoPrint/OctoPrint/releases/tag/2.0.0rc1) and I'm now helping plugins stay compatible with the new and upcoming OctoPrint releases, which is why you're receiving this PR.

---

Before submitting this PR, make sure you followed the following guidelines.

* [x] Your PR targets the `dev` branch
* [x] Your PR was opened from a new branch on your repository
* [x] Your PR does not contain unneeded files or code
* [x] Your changes match the existing coding style
* [x] You have tested your changes.

---

**What does this PR do ? What does it change or add ?**

This PR fixes the compatibility issues preventing this plugin from being installed on OctoPrint 2.0.0rc1.

In particular, it removes `admin_permission`, which doesn't exist anymore in OctoPrint 2.0.0 ([ref](https://docs.octoprint.org/en/dev/plugins/migration_2_0_0.html#removed-octoprint-server-admin-permission-octoprint-server-user-permission)) and replaces it with a proper `Permissions` check.

Minor improvements are also applied, like aligning python compatibility declared in `__init.py__` with the one in `pyproject.toml`, removing python2 support, clearing unused imports, etc.

**How did you test it ?**

I tested the installation on both OctoPrint 2.0.0rc1 and the latest stable release 1.11.7, and everything appears to work correctly.

**Screenshots (if applicable)**

**Is this linked to any existing opened issue ? Which one(s) ?**

**Other useful info**
